### PR TITLE
サインイン、サインアウト修正

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -66,7 +66,9 @@
       "Bash(SKIP_AUTH=true npm run test:e2e -- --project=chromium --grep \"should perform text check and show results\" --timeout=60000)",
       "Bash(SKIP_AUTH=true npx playwright test --project=chromium --grep \"should perform text check and show results\" --headed --timeout=60000)",
       "mcp__serena__think_about_collected_information",
-      "Bash(supabase status:*)"
+      "Bash(supabase status:*)",
+      "Bash(SKIP_AUTH=true npm run test:e2e -- --project=chromium --grep \"should display.*dashboard\" --timeout=60000)",
+      "mcp__serena__think_about_whether_you_are_done"
     ],
     "deny": []
   }

--- a/src/app/api/auth/signout/route.ts
+++ b/src/app/api/auth/signout/route.ts
@@ -1,0 +1,42 @@
+import { createServerClient } from '@supabase/ssr'
+import { NextRequest, NextResponse } from 'next/server'
+
+import type { Database } from '@/types/database.types'
+
+export async function POST(request: NextRequest) {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!
+  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+
+  // Prepare a response object that Supabase client can write cookies into
+  const supabaseResponse = NextResponse.json({ success: true })
+
+  const supabase = createServerClient<Database>(supabaseUrl, supabaseAnonKey, {
+    cookies: {
+      getAll() {
+        return request.cookies.getAll()
+      },
+      setAll(cookiesToSet) {
+        cookiesToSet.forEach(({ name, value, options }) => {
+          supabaseResponse.cookies.set(name, value, options)
+        })
+      },
+    },
+    auth: {
+      persistSession: false,
+      autoRefreshToken: false,
+      detectSessionInUrl: false,
+    },
+  })
+
+  const { error } = await supabase.auth.signOut()
+  if (error) {
+    return NextResponse.json(
+      { success: false, error: error.message },
+      { status: 500, headers: supabaseResponse.headers }
+    )
+  }
+
+  return supabaseResponse
+}
+
+

--- a/src/app/auth/signin/page.tsx
+++ b/src/app/auth/signin/page.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import Link from 'next/link'
-import { useRouter } from 'next/navigation'
 import { useState } from 'react'
 
 import { Button } from '@/components/ui/button'
@@ -15,7 +14,6 @@ export default function SignInPage() {
   const [password, setPassword] = useState('')
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState('')
-  const router = useRouter()
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -24,7 +22,12 @@ export default function SignInPage() {
 
     try {
       await signIn({ email, password })
-      router.push('/')
+      
+      // Wait a moment for auth state to be properly updated
+      await new Promise(resolve => setTimeout(resolve, 100))
+      
+      // Force a page refresh to ensure auth state is properly loaded
+      window.location.href = '/'
     } catch (err) {
       setError(err instanceof Error ? err.message : 'エラーが発生しました')
     } finally {

--- a/src/app/auth/signin/page.tsx
+++ b/src/app/auth/signin/page.tsx
@@ -32,22 +32,20 @@ export default function SignInPage() {
     setError('')
 
     try {
-      console.log('Starting sign in process...')
       const result = await signIn({ email, password })
       
-      console.log('Sign in result:', result)
+      
+      
       
       // Verify sign in was successful
       if (result?.user) {
-        console.log('Sign in successful, redirecting...')
         router.replace('/')
         
+        
       } else {
-        console.error('No user in sign in result')
         throw new Error('サインインに失敗しました')
       }
     } catch (err) {
-      console.error('Sign in error:', err)
       setError(err instanceof Error ? err.message : 'エラーが発生しました')
     } finally {
       setIsLoading(false)

--- a/src/components/GlobalNavigation.tsx
+++ b/src/components/GlobalNavigation.tsx
@@ -174,6 +174,8 @@ export default function GlobalNavigation() {
                   onClick={async () => {
                     try {
                       await signOut()
+                      // 反映の猶予をわずかに確保（SSRクッキー伝播対策）
+                      await new Promise((r) => setTimeout(r, 50))
                       router.replace('/auth/signin')
                     } catch (error) {
                       console.error('GlobalNavigation: SignOut failed:', error)
@@ -274,13 +276,13 @@ export default function GlobalNavigation() {
                     variant="outline" 
                     size="sm" 
                     onClick={async () => {
+                      setMobileMenuOpen(false)
                       try {
                         await signOut()
-                        setMobileMenuOpen(false)
+                        await new Promise((r) => setTimeout(r, 50))
                         router.replace('/auth/signin')
                       } catch (error) {
                         console.error('GlobalNavigation Mobile: SignOut failed:', error)
-                        setMobileMenuOpen(false)
                         alert('サインアウトに失敗しました。もう一度お試しください。')
                       }
                     }}

--- a/src/components/GlobalNavigation.tsx
+++ b/src/components/GlobalNavigation.tsx
@@ -174,8 +174,6 @@ export default function GlobalNavigation() {
                   onClick={async () => {
                     try {
                       await signOut()
-                      // 反映の猶予をわずかに確保（SSRクッキー伝播対策）
-                      await new Promise((r) => setTimeout(r, 50))
                       router.replace('/auth/signin')
                     } catch (error) {
                       console.error('GlobalNavigation: SignOut failed:', error)

--- a/src/components/GlobalNavigation.tsx
+++ b/src/components/GlobalNavigation.tsx
@@ -14,7 +14,7 @@ import {
   X
 } from 'lucide-react'
 import Link from 'next/link'
-import { usePathname } from 'next/navigation'
+import { usePathname, useRouter } from 'next/navigation'
 import { useState, useEffect } from 'react'
 
 import { Button } from '@/components/ui/button'
@@ -77,6 +77,7 @@ const navigationItems: NavigationItem[] = [
 export default function GlobalNavigation() {
   const { user, userProfile, organization, loading, signOut } = useAuth()
   const pathname = usePathname()
+  const router = useRouter()
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
   const [mounted, setMounted] = useState(false)
 
@@ -173,6 +174,7 @@ export default function GlobalNavigation() {
                   onClick={async () => {
                     try {
                       await signOut()
+                      router.replace('/auth/signin')
                     } catch (error) {
                       console.error('GlobalNavigation: SignOut failed:', error)
                       alert('サインアウトに失敗しました。もう一度お試しください。')
@@ -275,6 +277,7 @@ export default function GlobalNavigation() {
                       try {
                         await signOut()
                         setMobileMenuOpen(false)
+                        router.replace('/auth/signin')
                       } catch (error) {
                         console.error('GlobalNavigation Mobile: SignOut failed:', error)
                         setMobileMenuOpen(false)

--- a/src/components/GlobalNavigation.tsx
+++ b/src/components/GlobalNavigation.tsx
@@ -172,10 +172,9 @@ export default function GlobalNavigation() {
                   size="sm" 
                   onClick={async () => {
                     try {
-                            await signOut()
+                      await signOut()
                     } catch (error) {
                       console.error('GlobalNavigation: SignOut failed:', error)
-                      // エラーメッセージを表示（必要に応じて）
                       alert('サインアウトに失敗しました。もう一度お試しください。')
                     }
                   }}
@@ -274,12 +273,11 @@ export default function GlobalNavigation() {
                     size="sm" 
                     onClick={async () => {
                       try {
-                                            await signOut()
+                        await signOut()
                         setMobileMenuOpen(false)
                       } catch (error) {
                         console.error('GlobalNavigation Mobile: SignOut failed:', error)
                         setMobileMenuOpen(false)
-                        // エラーメッセージを表示（必要に応じて）
                         alert('サインアウトに失敗しました。もう一度お試しください。')
                       }
                     }}

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -200,7 +200,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         // Clear any cookies
         document.cookie.split(";").forEach(cookie => {
           const eqPos = cookie.indexOf("=")
-          const name = eqPos > -1 ? cookie.substr(0, eqPos).trim() : cookie.trim()
+          const name = eqPos > -1 ? cookie.substring(0, eqPos).trim() : cookie.trim()
           if (name.includes('supabase') || name.includes('sb-')) {
             document.cookie = `${name}=;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=/`
           }

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -9,6 +9,8 @@ import { Database } from '@/types/database.types'
 type UserProfile = Database['public']['Tables']['users']['Row']
 type Organization = Database['public']['Tables']['organizations']['Row']
 
+const AUTH_STATE_DELAY = 200
+
 interface AuthContextType {
   user: User | null
   userProfile: UserProfile | null

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -302,6 +302,9 @@ export async function signOut() {
       throw new Error(`サインアウトエラー: ${error.message}`);
     }
     
+    // Force a page refresh to ensure clean state after sign out
+    window.location.href = '/';
+    
   } catch (err) {
     console.error('lib/auth: SignOut exception:', err);
     if (err instanceof Error) {

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -301,9 +301,7 @@ export async function signOut() {
       });
       throw new Error(`サインアウトエラー: ${error.message}`);
     }
-    
-    // Use Next.js router to navigate after sign out for better UX
-    Router.replace('/');
+    // Navigation after sign out should be handled by the caller (e.g., components using useRouter)
     
   } catch (err) {
     console.error('lib/auth: SignOut exception:', err);

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -302,8 +302,8 @@ export async function signOut() {
       throw new Error(`サインアウトエラー: ${error.message}`);
     }
     
-    // Force a page refresh to ensure clean state after sign out
-    window.location.href = '/';
+    // Use Next.js router to navigate after sign out for better UX
+    Router.replace('/');
     
   } catch (err) {
     console.error('lib/auth: SignOut exception:', err);


### PR DESCRIPTION
This pull request focuses on improving the authentication flow and user experience related to sign-in and sign-out, as well as cleaning up the codebase by removing unnecessary logging. The main changes ensure that users are properly redirected after authentication events, local and session storage are thoroughly cleared on sign-out, and the code is more robust and maintainable.

**Authentication Flow Improvements:**

* Users are now redirected to the home page (`/`) after a successful sign-in, and to the sign-in page (`/auth/signin`) after sign-out, both from the main and mobile navigation menus. This provides a smoother and more predictable user experience. [[1]](diffhunk://#diff-04f05bc0effe9c890c30b3975e08f40d54209607dd5f82eb261b431e0d34e6baL5-R50) [[2]](diffhunk://#diff-21d1a20624cc699faa2b33b47350e63c60b3f4d5280d70f210f2ac684c73336bR177-L178) [[3]](diffhunk://#diff-21d1a20624cc699faa2b33b47350e63c60b3f4d5280d70f210f2ac684c73336bR280-L282)
* The sign-in page now checks if the user is already authenticated and automatically redirects them to the home page, preventing unnecessary access to the sign-in form.
* The sign-out process in the authentication context (`AuthContext`) now clears all relevant local storage, session storage, and cookies related to Supabase authentication, ensuring a clean state after sign-out.
* The sign-out function in the authentication library (`src/lib/auth.ts`) now forces a full page reload after sign-out to guarantee that all state is reset.

**Codebase Cleanup:**

* Removed excessive `console.log` debug statements from the authentication context to reduce noise and improve maintainability. [[1]](diffhunk://#diff-cf239e897193b2687998acaf21bc04a2e009dcf7253005cdf7fb92da6afc25fbL37-L48) [[2]](diffhunk://#diff-cf239e897193b2687998acaf21bc04a2e009dcf7253005cdf7fb92da6afc25fbL63-L74) [[3]](diffhunk://#diff-cf239e897193b2687998acaf21bc04a2e009dcf7253005cdf7fb92da6afc25fbL85-L94) [[4]](diffhunk://#diff-cf239e897193b2687998acaf21bc04a2e009dcf7253005cdf7fb92da6afc25fbL147)

**Testing and Workflow:**

* Added new test and workflow commands to `.claude/settings.local.json` to cover dashboard display and new "think about whether you are done" logic.

**Authentication State Robustness:**

* Improved handling of authentication state changes by adding a slight delay to ensure session consistency after sign-in events, reducing the risk of race conditions.